### PR TITLE
Shorten the file path if there are url parameters

### DIFF
--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -44,7 +44,8 @@ export const zerox = async ({
   const localPath = await downloadFile({ filePath, tempDir: tempDirectory });
   if (!localPath) throw "Failed to save file to local drive";
   const endOfPath = localPath.split("/")[localPath.split("/").length - 1];
-  const rawFileName = endOfPath.split(".")[0];
+  const [rawFileNameWithExtension] = endOfPath.split("?");
+  const rawFileName = rawFileNameWithExtension.split(".")[0];
   const fileName = rawFileName
     .replace(/[^\w\s]/g, "")
     .replace(/\s+/g, "_")


### PR DESCRIPTION
If the file path is too large (the case when there are url parameters in the file path), we see the following error: `ENAMETOOLONG: name too long, open '/tmp/zerox-temp-4660/`.

We want to remove any url parameters from the file path.