### PR TITLE
Adding HTML support for Zerox

### DIFF
--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -1,6 +1,7 @@
 import {
   convertPdfToImages,
   convertFileToPdf,
+  convertHtmlToPdf,
   downloadFile,
   formatMarkdown,
   isString,
@@ -56,6 +57,11 @@ export const zerox = async ({
   if (fileExtension !== ".png") {
     if (fileExtension === ".pdf") {
       pdfPath = localPath;
+    } else if (fileExtension === ".html") {
+      pdfPath = await convertHtmlToPdf({
+        htmlPath: localPath,
+        tempDir: tempDirectory,
+      });
     } else {
       pdfPath = await convertFileToPdf({
         localPath,

--- a/node-zerox/src/openAI.ts
+++ b/node-zerox/src/openAI.ts
@@ -13,6 +13,7 @@ export const getCompletion = async ({
     Convert the following PDF page to markdown.
     Return only the markdown with no explanation text. Do not include deliminators like '''markdown.
     You must include all information on the page. Do not exclude headers, footers, or subtext.
+    If the image doesn't contain any text, return an empty string.
   `;
 
   // Default system message.


### PR DESCRIPTION
libreoffice-convert encounters edges cases where it cannot locate the input and output files when converting HTML so writing our own `soffice` cli wrapper. 