### PR TITLE
feat: allow specifying page numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const result = await zerox({
   maintainFormat: false, // Slower but helps maintain consistent formatting.
   model: 'gpt-4o-mini' // Model to use (gpt-4o-mini or gpt-4o).
   outputDir: undefined, // Save combined result.md to a file.
-  pagesToConvertAsImages: -1, // Page numbers to convert to image as array (e.g. `[1,2,3]`) or a number (e.g. `1`). Set to -1 to convert all pages.
+  pagesToConvertAsImages: -1, // Page numbers to convert to image as array (e.g. `[1, 2, 3]`) or a number (e.g. `1`). Set to -1 to convert all pages.
   tempDir: "/os/tmp", // Directory to use for temporary files (default: system temp directory).
 });
 ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ const result = await zerox({
   maintainFormat: false, // Slower but helps maintain consistent formatting.
   model: 'gpt-4o-mini' // Model to use (gpt-4o-mini or gpt-4o).
   outputDir: undefined, // Save combined result.md to a file.
+  pagesToConvertAsImages: -1, // Page numbers to convert to image as array (e.g. `[1,2,3]`) or a number (e.g. `1`). Set to -1 to convert all pages.
   tempDir: "/os/tmp", // Directory to use for temporary files (default: system temp directory).
 });
 ```

--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -67,8 +67,8 @@ export const zerox = async ({
     // Convert the file to a series of images
     await convertPdfToImages({
       localPath: pdfPath,
-      tempDir: tempDirectory,
       pagesToConvertAsImages,
+      tempDir: tempDirectory,
     });
   }
 

--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -20,6 +20,7 @@ export const zerox = async ({
   model = ModelOptions.gpt_4o_mini,
   openaiAPIKey = "",
   outputDir,
+  pagesToConvertAsImages = -1,
   tempDir = os.tmpdir(),
 }: ZeroxArgs): Promise<ZeroxOutput> => {
   let inputTokenCount = 0;
@@ -64,7 +65,11 @@ export const zerox = async ({
       });
     }
     // Convert the file to a series of images
-    await convertPdfToImages({ localPath: pdfPath, tempDir: tempDirectory });
+    await convertPdfToImages({
+      localPath: pdfPath,
+      tempDir: tempDirectory,
+      pagesToConvertAsImages,
+    });
   }
 
   const endOfPath = localPath.split("/")[localPath.split("/").length - 1];

--- a/node-zerox/src/types.ts
+++ b/node-zerox/src/types.ts
@@ -6,6 +6,7 @@ export interface ZeroxArgs {
   model?: ModelOptions;
   openaiAPIKey?: string;
   outputDir?: string;
+  pagesToConvertAsImages?: number | number[];
   tempDir?: string;
 }
 

--- a/node-zerox/src/utils.ts
+++ b/node-zerox/src/utils.ts
@@ -92,12 +92,12 @@ export const downloadFile = async ({
 // @TODO: pull dimensions from the original document. Also, look into rotated pages
 export const convertPdfToImages = async ({
   localPath,
-  tempDir,
   pagesToConvertAsImages,
+  tempDir,
 }: {
   localPath: string;
-  tempDir: string;
   pagesToConvertAsImages: number | number[];
+  tempDir: string;
 }) => {
   const options = {
     density: 300,

--- a/node-zerox/src/utils.ts
+++ b/node-zerox/src/utils.ts
@@ -93,9 +93,11 @@ export const downloadFile = async ({
 export const convertPdfToImages = async ({
   localPath,
   tempDir,
+  pagesToConvertAsImages,
 }: {
   localPath: string;
   tempDir: string;
+  pagesToConvertAsImages: number | number[];
 }) => {
   const options = {
     density: 300,
@@ -108,7 +110,7 @@ export const convertPdfToImages = async ({
   const storeAsImage = fromPath(localPath, options);
 
   try {
-    const convertResults = await storeAsImage.bulk(-1, {
+    const convertResults = await storeAsImage.bulk(pagesToConvertAsImages, {
       responseType: "buffer",
     });
     await Promise.all(


### PR DESCRIPTION
# Context

<!-- Describe the situation _before_ this PR and why it needs to be changed -->

The lib uses GPT-4o / GPT-4o-mini to convert document to images. While the upside of GPT is that it has good accuracy, it can be quite slow.

In some cases, you don't want to convert the whole documents and you only need to extract the text from a few pages, and discarding the results after the processing makes it much slower than it could be.

The goal of this PR is to allow to specify which pages to convert to images.

# Description

<!-- Describe the changes contained in this PR, and how it will make things better -->

It adds a parameter `pagesToConvertAsImages` which is set to `-1` by default. This parameter is directly passed to the call to `pdf2pic` which supports specifying the pages to convert.

Thus, this parameter follows the same format as `pdf2pic`, namely:

- `-1` to convert all pages
- `number` (e.g. `1`) to convert a single page
- `number[]` (e.g. `[1, 2, 3]`) to convert multiple pages

Types and README.md are updated accordingly.

# Testing notes

<!-- Describe the best way to test this PR, such as test setup instructions and suggested tests scenarios -->

Here's a sample script if you want to see how it would be used:

```js
import { zerox } from "./src/index";
import { writeFile } from "node:fs/promises";

async function main() {
  // All pages (i.e. no value provided for `pagesToConvertAsImages`)
  const resultAllPages = await zerox({
    filePath: "https://www.sldttc.org/allpdf/21583473018.pdf",
    openaiAPIKey: process.env.OPENAI_API_KEY,
  });

  await writeFile(
    "output-all-pages.md",
    resultAllPages.pages.map((p) => p.content).join("\n")
  );

  // Page 2
  const resultPage1 = await zerox({
    filePath: "https://www.sldttc.org/allpdf/21583473018.pdf",
    openaiAPIKey: process.env.OPENAI_API_KEY,
    pagesToConvertAsImages: 2,
  });

  await writeFile(
    "output-page-2.md",
    resultPage1.pages.map((p) => p.content).join("\n")
  );

  // Page 2 and 3
  const resultPage2and3 = await zerox({
    filePath: "https://www.sldttc.org/allpdf/21583473018.pdf",
    openaiAPIKey: process.env.OPENAI_API_KEY,
    pagesToConvertAsImages: [2, 3],
  });

  await writeFile(
    "output-page-2-and-3.md",
    resultPage2and3.pages.map((p) => p.content).join("\n")
  );
}

main();
```

# Open questions

Some questions before moving forwards:

1. Are you open to adding this parameter to the lib?
2. I didn't have a lot of inspiration for the parameter name, so any suggestion is welcome.
3. Currently, if you don't convert all the pages, the result `page` number in the `formattedPages` output won't be correct (because we use the array index). Is this a problem?
4. Currently, if the provided page numbers are out of range, it will crash when calling OpenAI. Should it be handled by the lib, and if so how the error handling should be done (if you have any examples)? Or is it reasonable to expect that the user will enter a valid page range?
5. Should this be added to the Python lib? I'm not a Python dev, but I can try to add it.
6. It uses the `pdf2pic` format to provide the pages. Is this OK, or should it be abstracted? It might also depend what format would be used by the Python lib.

Feel free to let me know if I missed anything (code-wise or documentation-wise).
