### PR TITLE
fix: page numbering when only converting specific pages

### DIFF
--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -52,6 +52,12 @@ export const zerox = async ({
     throw new Error("File extension missing");
   }
 
+  // Sort the `pagesToConvertAsImages` array to make sure we use the right index
+  // for `formattedPages` as `pdf2pic` always returns images in order
+  if (Array.isArray(pagesToConvertAsImages)) {
+    pagesToConvertAsImages.sort((a, b) => a - b);
+  }
+
   // Convert file to PDF if necessary
   if (fileExtension !== ".png") {
     let pdfPath: string;
@@ -170,7 +176,21 @@ export const zerox = async ({
   const endTime = new Date();
   const completionTime = endTime.getTime() - startTime.getTime();
   const formattedPages = aggregatedMarkdown.map((el, i) => {
-    return { content: el, page: i + 1, contentLength: el.length };
+    let pageNumber;
+    // If we convert all pages, just use the array index
+    if (pagesToConvertAsImages === -1) {
+      pageNumber = i + 1;
+    }
+    // Else if we convert specific pages, use the page number from the parameter
+    else if (Array.isArray(pagesToConvertAsImages)) {
+      pageNumber = pagesToConvertAsImages[i];
+    }
+    // Else, the parameter is a number and use it for the page number
+    else {
+      pageNumber = pagesToConvertAsImages;
+    }
+
+    return { content: el, page: pageNumber, contentLength: el.length };
   });
 
   return {


### PR DESCRIPTION
# Context

<!-- Describe the situation _before_ this PR and why it needs to be changed -->

Follow up of https://github.com/getomni-ai/zerox/pull/23 (cf. https://github.com/getomni-ai/zerox/pull/23#issuecomment-2337198811) to fix page numbering when not converting all pages.

When we only convert specific pages, the `formattedPages.page` index will not be correct.

# Description

<!-- Describe the changes contained in this PR, and how it will make things better -->

Depending on the use case, we can retrieve the proper index:

- If `pagesToConvertAsImages === -1`: we simply use the `aggregatedMarkdown` array index, same as before.
- If `pagesToConvertAsImages` is an array, we use the `aggregatedMarkdown`  array index to find the corresponding element in `pagesToConvertAsImages`
- If `pagesToConvertAsImages` is a number, we simply use that value

Note: `pdf2pic` will always return the pages in order, regardless the initial order in `pagesToConvertAsImages` parameter. Therefore, it's better to always sort the `pagesToConvertAsImages` array for consistency.

# Testing notes

<!-- Describe the best way to test this PR, such as test setup instructions and suggested tests scenarios -->

Here are a few tests cases (check the output to see if the `page` number is correct):

```js
import { zerox } from "./src/index";
import { writeFile } from "node:fs/promises";

async function main() {
  // All pages (i.e. no value provided for `pagesToConvertAsImages`)
  const resultAllPages = await zerox({
    filePath: "https://www.sldttc.org/allpdf/21583473018.pdf",
    openaiAPIKey: process.env.OPENAI_API_KEY,
  });
  console.log(
    resultAllPages.pages.map((p) => ({
      ...p,
      content: p.content.slice(0, 100),
    }))
  );

  // Page 2
  const resultPage1 = await zerox({
    filePath: "https://www.sldttc.org/allpdf/21583473018.pdf",
    openaiAPIKey: process.env.OPENAI_API_KEY,
    pagesToConvertAsImages: 2,
  });
  console.log(
    resultPage1.pages.map((p) => ({
      ...p,
      content: p.content.slice(0, 100),
    }))
  );

  // Page 2 and 3
  const resultPage2and3 = await zerox({
    filePath: "https://www.sldttc.org/allpdf/21583473018.pdf",
    openaiAPIKey: process.env.OPENAI_API_KEY,
    pagesToConvertAsImages: [2, 3],
  });
  console.log(
    resultPage2and3.pages.map((p) => ({
      ...p,
      content: p.content.slice(0, 100),
    }))
  );

  // Page 3 and 2
  const resultPage3and2 = await zerox({
    filePath: "https://www.sldttc.org/allpdf/21583473018.pdf",
    openaiAPIKey: process.env.OPENAI_API_KEY,
    pagesToConvertAsImages: [3, 2],
  });
  console.log(
    resultPage3and2.pages.map((p) => ({
      ...p,
      content: p.content.slice(0, 100),
    }))
  );
}

main();
```