### PR TITLE
fix: allow empty select_pages again

### DIFF
--- a/py_zerox/pyzerox/core/zerox.py
+++ b/py_zerox/pyzerox/core/zerox.py
@@ -86,9 +86,10 @@ async def zerox(
     # If select_pages is a single integer, convert it to a list for consistency
     if isinstance(select_pages, int):
         select_pages = [select_pages]
-    
+
     # Sort the pages to maintain consistency
-    select_pages = sorted(select_pages)
+    if select_pages is not None:
+        select_pages = sorted(select_pages)
 
     # Ensure the output directory exists
     if output_dir:


### PR DESCRIPTION
Restores operation of examples where `select_pages` was empty (= use all pages).

Fixes #42.