### PR TITLE
Fix ENAMETOOLONG error by truncating file names

### DIFF
--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -84,7 +84,8 @@ export const zerox = async ({
   const fileName = rawFileName
     .replace(/[^\w\s]/g, "")
     .replace(/\s+/g, "_")
-    .toLowerCase();
+    .toLowerCase()
+    .substring(0, 255); // Truncate file name to 255 characters to prevent ENAMETOOLONG errors
 
   // Get list of converted images
   const files = await fs.readdir(tempDirectory);

--- a/py_zerox/pyzerox/core/zerox.py
+++ b/py_zerox/pyzerox/core/zerox.py
@@ -119,7 +119,9 @@ async def zerox(
         
         raw_file_name = os.path.splitext(os.path.basename(local_path))[0]
         file_name = "".join(c.lower() if c.isalnum() else "_" for c in raw_file_name)
-        
+        # Truncate file name to 255 characters to prevent ENAMETOOLONG errors
+        file_name = file_name[:255]
+
         # create a subset pdf in temp dir with only the requested pages if select_pages is provided
         if select_pages is not None:
             subset_pdf_create_kwargs = {"original_pdf_path":local_path, "select_pages":select_pages, 


### PR DESCRIPTION
Fixes #60

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/getomni-ai/zerox/issues/60?shareId=a6d2e128-cc9d-40de-83c8-7dcf21c69b80).