### PR TITLE
Improve accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ const result = await zerox({
   outputDir: undefined, // Save combined result.md to a file.
   pagesToConvertAsImages: -1, // Page numbers to convert to image as array (e.g. `[1, 2, 3]`) or a number (e.g. `1`). Set to -1 to convert all pages.
   tempDir: "/os/tmp", // Directory to use for temporary files (default: system temp directory).
+  trimEdges: false, // True by default, trims pixels from all edges that contain values similar to the given background colour, which defaults to that of the top-left pixel.
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ const result = await zerox({
   outputDir: undefined, // Save combined result.md to a file.
   pagesToConvertAsImages: -1, // Page numbers to convert to image as array (e.g. `[1, 2, 3]`) or a number (e.g. `1`). Set to -1 to convert all pages.
   tempDir: "/os/tmp", // Directory to use for temporary files (default: system temp directory).
-  trimEdges: false, // True by default, trims pixels from all edges that contain values similar to the given background colour, which defaults to that of the top-left pixel.
+  trimEdges: true, // True by default, trims pixels from all edges that contain values similar to the given background colour, which defaults to that of the top-left pixel.
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ const result = await zerox({
   // Optional
   cleanup: true, // Clear images from tmp after run.
   concurrency: 10, // Number of pages to run at a time.
+  correctOrientation: true, // True by default, attempts to identify and correct page orientation.
   maintainFormat: false, // Slower but helps maintain consistent formatting.
   model: 'gpt-4o-mini' // Model to use (gpt-4o-mini or gpt-4o).
   outputDir: undefined, // Save combined result.md to a file.

--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -16,6 +16,7 @@ import pLimit, { Limit } from "p-limit";
 export const zerox = async ({
   cleanup = true,
   concurrency = 10,
+  correctOrientation = true,
   filePath,
   llmParams = {},
   maintainFormat = false,
@@ -74,6 +75,7 @@ export const zerox = async ({
     }
     // Convert the file to a series of images
     await convertPdfToImages({
+      correctOrientation,
       localPath: pdfPath,
       pagesToConvertAsImages,
       tempDir: tempDirectory,

--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -24,6 +24,7 @@ export const zerox = async ({
   outputDir,
   pagesToConvertAsImages = -1,
   tempDir = os.tmpdir(),
+  trimEdges = true,
 }: ZeroxArgs): Promise<ZeroxOutput> => {
   let inputTokenCount = 0;
   let outputTokenCount = 0;
@@ -76,6 +77,7 @@ export const zerox = async ({
       localPath: pdfPath,
       pagesToConvertAsImages,
       tempDir: tempDirectory,
+      trimEdges,
     });
   }
 

--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -75,8 +75,10 @@ export const zerox = async ({
     }
     // Convert the file to a series of images
     await convertPdfToImages({
+      cleanup,
       correctOrientation,
       localPath: pdfPath,
+      outputDir: outputDir || './',
       pagesToConvertAsImages,
       tempDir: tempDirectory,
       trimEdges,

--- a/node-zerox/src/types.ts
+++ b/node-zerox/src/types.ts
@@ -1,6 +1,7 @@
 export interface ZeroxArgs {
   cleanup?: boolean;
   concurrency?: number;
+  correctOrientation?: boolean;
   filePath: string;
   llmParams?: LLMParams;
   maintainFormat?: boolean;

--- a/node-zerox/src/types.ts
+++ b/node-zerox/src/types.ts
@@ -9,6 +9,7 @@ export interface ZeroxArgs {
   outputDir?: string;
   pagesToConvertAsImages?: number | number[];
   tempDir?: string;
+  trimEdges?: boolean;
 }
 
 export enum ModelOptions {


### PR DESCRIPTION
This PR makes a few changes to `node-zerox` with the goal of improving overall accuracy of OCR.

1. The resolution of image representing PDF page has been increased from `1056` to `2048`.
2. Auto orientation correction is now configurable. It can be turned off by setting `correctOrientation` as `false`.
3. Low confidence Tesseract orientation suggestions will be ignored. This is non configurable, and set to 60%.
4. Whitespace around the page serves no purpose in OCR, trimming it away can allow more pixels to show actual content. This is turned on by default and can be switched off by setting `trimEdges` as `false`.
5. After step 4, to make sure the content fills up the max height of `2048`, we make an educated guess and extract another image of the same page but with increased height, so that after the whitespace trimming, the image is close to `2048px` in height. This will have most impact in pages with lots of white space, and small-sized content bunched together on one side.