### PR TITLE
Use uuid as file name

### DIFF
--- a/node-zerox/src/utils.ts
+++ b/node-zerox/src/utils.ts
@@ -9,6 +9,7 @@ import fs from "fs-extra";
 import mime from "mime-types";
 import path from "path";
 import sharp from "sharp";
+import { v4 as uuidv4 } from "uuid";
 
 const convertAsync = promisify(convert);
 
@@ -94,7 +95,9 @@ export const downloadFile = async ({
 }): Promise<{ extension: string; localPath: string }> => {
   // Shorten the file name by removing URL parameters
   const baseFileName = path.basename(filePath.split("?")[0]);
-  const localPath = path.join(tempDir, baseFileName);
+  const fileNameExt = path.extname(baseFileName);
+  const localPath = path.join(tempDir, uuidv4() + fileNameExt);
+
   let mimetype;
 
   // Check if filePath is a URL

--- a/node-zerox/src/utils.ts
+++ b/node-zerox/src/utils.ts
@@ -93,9 +93,7 @@ export const downloadFile = async ({
   filePath: string;
   tempDir: string;
 }): Promise<{ extension: string; localPath: string }> => {
-  // Shorten the file name by removing URL parameters
-  const baseFileName = path.basename(filePath.split("?")[0]);
-  const fileNameExt = path.extname(baseFileName);
+  const fileNameExt = path.extname(filePath.split("?")[0]);
   const localPath = path.join(tempDir, uuidv4() + fileNameExt);
 
   let mimetype;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "pdf2pic": "^3.1.1",
         "sharp": "^0.33.5",
         "tesseract.js": "^5.1.1",
-        "util": "^0.12.5"
+        "util": "^0.12.5",
+        "uuid": "^11.0.3"
       },
       "devDependencies": {
         "@types/fs-extra": "^11.0.4",
@@ -1451,6 +1452,18 @@
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "pdf2pic": "^3.1.1",
     "sharp": "^0.33.5",
     "tesseract.js": "^5.1.1",
-    "util": "^0.12.5"
+    "util": "^0.12.5",
+    "uuid": "^11.0.3"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
If the file names are long, especially when the PDF has unicode file name & its name is url encoded, it might exceed the max allowed filename length in linux (and probably other OSes) which is 255 characters.

This would be fine in s3 as that has a file name limit of 1024 characters, but would result in `ENAMETOOLONG` errors when Zerox tries to download and write to the disk.

This PR prevents `ENAMETOOLONG` errors by using a UUIDv4 as the file name.