### PR TITLE
add encoding to avoid error in windows

### DIFF
--- a/py_zerox/pyzerox/core/zerox.py
+++ b/py_zerox/pyzerox/core/zerox.py
@@ -165,7 +165,7 @@ async def zerox(
         # Write the aggregated markdown to a file
         if output_dir:
             result_file_path = os.path.join(output_dir, f"{file_name}.md")
-            async with aiofiles.open(result_file_path, "w") as f:
+            async with aiofiles.open(result_file_path, "w", encoding="utf-8") as f:
                 await f.write("\n\n".join(aggregated_markdown))
 
         # Cleanup the downloaded PDF file


### PR DESCRIPTION
# Changes:

- Add encoding to utf-8 the default encoding from linux and mac to avoid error in windows for not alphabetical letter.

# Notes:

n/a