### PR TITLE
Use Tesseract's Orientation detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ node-zerox/tests/results
 eng.traineddata
 .DS_Store
 
+# Ignore Tesseract's data
+osd.traineddata
+
 # ==========================
 #         Python
 # ==========================

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ const result = await zerox({
   concurrency: 10, // Number of pages to run at a time.
   correctOrientation: true, // True by default, attempts to identify and correct page orientation.
   maintainFormat: false, // Slower but helps maintain consistent formatting.
+  maxTesseractWorkers: -1, // Maximum number of tesseract workers. Zerox will start with a lower number and only reach maxTesseractWorkers if needed.
   model: 'gpt-4o-mini' // Model to use (gpt-4o-mini or gpt-4o).
   outputDir: undefined, // Save combined result.md to a file.
   pagesToConvertAsImages: -1, // Page numbers to convert to image as array (e.g. `[1, 2, 3]`) or a number (e.g. `1`). Set to -1 to convert all pages.

--- a/node-zerox/src/constants.ts
+++ b/node-zerox/src/constants.ts
@@ -1,4 +1,4 @@
 // This is a rough guess; this will be used to create Tesseract workers by default,
 // that cater to this many pages. If a document has more than this many pages,
 // then more workers will be created dynamically.
-export const NUM_STARTING_WORKERS = 3 * 4;
+export const NUM_STARTING_WORKERS = 3;

--- a/node-zerox/src/constants.ts
+++ b/node-zerox/src/constants.ts
@@ -1,0 +1,4 @@
+// This is a rough guess; this will be used to create Tesseract workers by default,
+// that cater to this many pages. If a document has more than this many pages,
+// then more workers will be created dynamically.
+export const NUM_STARTING_WORKERS = 3 * 4;

--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -3,7 +3,9 @@ import {
   convertPdfToImages,
   downloadFile,
   formatMarkdown,
+  initTesseractScheduler,
   isString,
+  terminateScheduler,
 } from "./utils";
 import { getCompletion } from "./openAI";
 import { ModelOptions, ZeroxArgs, ZeroxOutput } from "./types";
@@ -12,6 +14,7 @@ import fs from "fs-extra";
 import os from "os";
 import path from "path";
 import pLimit, { Limit } from "p-limit";
+import { NUM_STARTING_WORKERS } from "./constants";
 
 export const zerox = async ({
   cleanup = true,
@@ -20,6 +23,7 @@ export const zerox = async ({
   filePath,
   llmParams = {},
   maintainFormat = false,
+  maxTesseractWorkers = -1,
   model = ModelOptions.gpt_4o_mini,
   onPostProcess,
   onPreProcess,
@@ -45,181 +49,197 @@ export const zerox = async ({
     throw new Error("Missing file path");
   }
 
-  // Ensure temp directory exists + create temp folder
-  const rand = Math.floor(1000 + Math.random() * 9000).toString();
-  const tempDirectory = path.join(tempDir || os.tmpdir(), `zerox-temp-${rand}`);
-  await fs.ensureDir(tempDirectory);
-
-  // Download the PDF. Get file name.
-  const { extension, localPath } = await downloadFile({
-    filePath,
-    tempDir: tempDirectory,
-  });
-  if (!localPath) throw "Failed to save file to local drive";
-
-  // Sort the `pagesToConvertAsImages` array to make sure we use the right index
-  // for `formattedPages` as `pdf2pic` always returns images in order
-  if (Array.isArray(pagesToConvertAsImages)) {
-    pagesToConvertAsImages.sort((a, b) => a - b);
+  if (correctOrientation) {
+    const workerCount =
+      maxTesseractWorkers !== -1 && maxTesseractWorkers < NUM_STARTING_WORKERS
+        ? maxTesseractWorkers
+        : NUM_STARTING_WORKERS;
+    initTesseractScheduler(workerCount);
   }
 
-  // Convert file to PDF if necessary
-  if (extension !== ".png") {
-    let pdfPath: string;
-    if (extension === ".pdf") {
-      pdfPath = localPath;
-    } else {
-      pdfPath = await convertFileToPdf({
-        extension,
-        localPath,
+  try {
+    // Ensure temp directory exists + create temp folder
+    const rand = Math.floor(1000 + Math.random() * 9000).toString();
+    const tempDirectory = path.join(
+      tempDir || os.tmpdir(),
+      `zerox-temp-${rand}`
+    );
+    await fs.ensureDir(tempDirectory);
+
+    // Download the PDF. Get file name.
+    const { extension, localPath } = await downloadFile({
+      filePath,
+      tempDir: tempDirectory,
+    });
+    if (!localPath) throw "Failed to save file to local drive";
+
+    // Sort the `pagesToConvertAsImages` array to make sure we use the right index
+    // for `formattedPages` as `pdf2pic` always returns images in order
+    if (Array.isArray(pagesToConvertAsImages)) {
+      pagesToConvertAsImages.sort((a, b) => a - b);
+    }
+
+    // Convert file to PDF if necessary
+    if (extension !== ".png") {
+      let pdfPath: string;
+      if (extension === ".pdf") {
+        pdfPath = localPath;
+      } else {
+        pdfPath = await convertFileToPdf({
+          extension,
+          localPath,
+          tempDir: tempDirectory,
+        });
+      }
+      // Convert the file to a series of images
+      await convertPdfToImages({
+        correctOrientation,
+        localPath: pdfPath,
+        maxTesseractWorkers,
+        pagesToConvertAsImages,
         tempDir: tempDirectory,
+        trimEdges,
       });
     }
-    // Convert the file to a series of images
-    await convertPdfToImages({
-      correctOrientation,
-      localPath: pdfPath,
-      pagesToConvertAsImages,
-      tempDir: tempDirectory,
-      trimEdges,
+
+    const endOfPath = localPath.split("/")[localPath.split("/").length - 1];
+    const rawFileName = endOfPath.split(".")[0];
+    const fileName = rawFileName
+      .replace(/[^\w\s]/g, "")
+      .replace(/\s+/g, "_")
+      .toLowerCase()
+      .substring(0, 255); // Truncate file name to 255 characters to prevent ENAMETOOLONG errors
+
+    // Get list of converted images
+    const files = await fs.readdir(tempDirectory);
+    const images = files.filter((file) => file.endsWith(".png"));
+
+    if (maintainFormat) {
+      // Use synchronous processing
+      for (const image of images) {
+        const imagePath = path.join(tempDirectory, image);
+        try {
+          const { content, inputTokens, outputTokens } = await getCompletion({
+            apiKey: openaiAPIKey,
+            imagePath,
+            llmParams,
+            maintainFormat,
+            model,
+            priorPage,
+          });
+          const formattedMarkdown = formatMarkdown(content);
+          inputTokenCount += inputTokens;
+          outputTokenCount += outputTokens;
+
+          // Update prior page to result from last processing step
+          priorPage = formattedMarkdown;
+
+          // Add all markdown results to array
+          aggregatedMarkdown.push(formattedMarkdown);
+        } catch (error) {
+          console.error(`Failed to process image ${image}:`, error);
+          throw error;
+        }
+      }
+    } else {
+      // Process in parallel with a limit on concurrent pages
+      const processPage = async (
+        image: string,
+        pageNumber: number
+      ): Promise<string | null> => {
+        const imagePath = path.join(tempDirectory, image);
+        try {
+          if (onPreProcess) {
+            await onPreProcess({ imagePath, pageNumber });
+          }
+
+          const { content, inputTokens, outputTokens } = await getCompletion({
+            apiKey: openaiAPIKey,
+            imagePath,
+            llmParams,
+            maintainFormat,
+            model,
+            priorPage,
+          });
+          const formattedMarkdown = formatMarkdown(content);
+          inputTokenCount += inputTokens;
+          outputTokenCount += outputTokens;
+
+          // Update prior page to result from last processing step
+          priorPage = formattedMarkdown;
+
+          if (onPostProcess) {
+            await onPostProcess({ content, pageNumber });
+          }
+
+          // Add all markdown results to array
+          return formattedMarkdown;
+        } catch (error) {
+          console.error(`Failed to process image ${image}:`, error);
+          throw error;
+        }
+      };
+
+      // Function to process pages with concurrency limit
+      const processPagesInBatches = async (images: string[], limit: Limit) => {
+        const results: (string | null)[] = [];
+
+        const promises = images.map((image, index) =>
+          limit(() =>
+            processPage(image, index + 1).then((result) => {
+              results[index] = result;
+            })
+          )
+        );
+
+        await Promise.all(promises);
+        return results;
+      };
+
+      const limit = pLimit(concurrency);
+      const results = await processPagesInBatches(images, limit);
+      const filteredResults = results.filter(isString);
+      aggregatedMarkdown.push(...filteredResults);
+    }
+
+    // Write the aggregated markdown to a file
+    if (outputDir) {
+      const resultFilePath = path.join(outputDir, `${fileName}.md`);
+      await fs.writeFile(resultFilePath, aggregatedMarkdown.join("\n\n"));
+    }
+
+    // Cleanup the downloaded PDF file
+    if (cleanup) await fs.remove(tempDirectory);
+
+    // Format JSON response
+    const endTime = new Date();
+    const completionTime = endTime.getTime() - startTime.getTime();
+    const formattedPages = aggregatedMarkdown.map((el, i) => {
+      let pageNumber;
+      // If we convert all pages, just use the array index
+      if (pagesToConvertAsImages === -1) {
+        pageNumber = i + 1;
+      }
+      // Else if we convert specific pages, use the page number from the parameter
+      else if (Array.isArray(pagesToConvertAsImages)) {
+        pageNumber = pagesToConvertAsImages[i];
+      }
+      // Else, the parameter is a number and use it for the page number
+      else {
+        pageNumber = pagesToConvertAsImages;
+      }
+
+      return { content: el, page: pageNumber, contentLength: el.length };
     });
-  }
 
-  const endOfPath = localPath.split("/")[localPath.split("/").length - 1];
-  const rawFileName = endOfPath.split(".")[0];
-  const fileName = rawFileName
-    .replace(/[^\w\s]/g, "")
-    .replace(/\s+/g, "_")
-    .toLowerCase()
-    .substring(0, 255); // Truncate file name to 255 characters to prevent ENAMETOOLONG errors
-
-  // Get list of converted images
-  const files = await fs.readdir(tempDirectory);
-  const images = files.filter((file) => file.endsWith(".png"));
-
-  if (maintainFormat) {
-    // Use synchronous processing
-    for (const image of images) {
-      const imagePath = path.join(tempDirectory, image);
-      try {
-        const { content, inputTokens, outputTokens } = await getCompletion({
-          apiKey: openaiAPIKey,
-          imagePath,
-          llmParams,
-          maintainFormat,
-          model,
-          priorPage,
-        });
-        const formattedMarkdown = formatMarkdown(content);
-        inputTokenCount += inputTokens;
-        outputTokenCount += outputTokens;
-
-        // Update prior page to result from last processing step
-        priorPage = formattedMarkdown;
-
-        // Add all markdown results to array
-        aggregatedMarkdown.push(formattedMarkdown);
-      } catch (error) {
-        console.error(`Failed to process image ${image}:`, error);
-        throw error;
-      }
-    }
-  } else {
-    // Process in parallel with a limit on concurrent pages
-    const processPage = async (
-      image: string,
-      pageNumber: number
-    ): Promise<string | null> => {
-      const imagePath = path.join(tempDirectory, image);
-      try {
-        if (onPreProcess) {
-          await onPreProcess({ imagePath, pageNumber });
-        }
-
-        const { content, inputTokens, outputTokens } = await getCompletion({
-          apiKey: openaiAPIKey,
-          imagePath,
-          llmParams,
-          maintainFormat,
-          model,
-          priorPage,
-        });
-        const formattedMarkdown = formatMarkdown(content);
-        inputTokenCount += inputTokens;
-        outputTokenCount += outputTokens;
-
-        // Update prior page to result from last processing step
-        priorPage = formattedMarkdown;
-
-        if (onPostProcess) {
-          await onPostProcess({ content, pageNumber });
-        }
-
-        // Add all markdown results to array
-        return formattedMarkdown;
-      } catch (error) {
-        console.error(`Failed to process image ${image}:`, error);
-        throw error;
-      }
+    return {
+      completionTime,
+      fileName,
+      inputTokens: inputTokenCount,
+      outputTokens: outputTokenCount,
+      pages: formattedPages,
     };
-
-    // Function to process pages with concurrency limit
-    const processPagesInBatches = async (images: string[], limit: Limit) => {
-      const results: (string | null)[] = [];
-
-      const promises = images.map((image, index) =>
-        limit(() =>
-          processPage(image, index + 1).then((result) => {
-            results[index] = result;
-          })
-        )
-      );
-
-      await Promise.all(promises);
-      return results;
-    };
-
-    const limit = pLimit(concurrency);
-    const results = await processPagesInBatches(images, limit);
-    const filteredResults = results.filter(isString);
-    aggregatedMarkdown.push(...filteredResults);
+  } finally {
+    if (correctOrientation) terminateScheduler();
   }
-
-  // Write the aggregated markdown to a file
-  if (outputDir) {
-    const resultFilePath = path.join(outputDir, `${fileName}.md`);
-    await fs.writeFile(resultFilePath, aggregatedMarkdown.join("\n\n"));
-  }
-
-  // Cleanup the downloaded PDF file
-  if (cleanup) await fs.remove(tempDirectory);
-
-  // Format JSON response
-  const endTime = new Date();
-  const completionTime = endTime.getTime() - startTime.getTime();
-  const formattedPages = aggregatedMarkdown.map((el, i) => {
-    let pageNumber;
-    // If we convert all pages, just use the array index
-    if (pagesToConvertAsImages === -1) {
-      pageNumber = i + 1;
-    }
-    // Else if we convert specific pages, use the page number from the parameter
-    else if (Array.isArray(pagesToConvertAsImages)) {
-      pageNumber = pagesToConvertAsImages[i];
-    }
-    // Else, the parameter is a number and use it for the page number
-    else {
-      pageNumber = pagesToConvertAsImages;
-    }
-
-    return { content: el, page: pageNumber, contentLength: el.length };
-  });
-
-  return {
-    completionTime,
-    fileName,
-    inputTokens: inputTokenCount,
-    outputTokens: outputTokenCount,
-    pages: formattedPages,
-  };
 };

--- a/node-zerox/src/types.ts
+++ b/node-zerox/src/types.ts
@@ -5,6 +5,7 @@ export interface ZeroxArgs {
   filePath: string;
   llmParams?: LLMParams;
   maintainFormat?: boolean;
+  maxTesseractWorkers?: number;
   model?: ModelOptions | string;
   onPostProcess?: (params: {
     content: string;

--- a/node-zerox/src/utils.ts
+++ b/node-zerox/src/utils.ts
@@ -9,9 +9,12 @@ import fs from "fs-extra";
 import mime from "mime-types";
 import path from "path";
 import sharp from "sharp";
+import { NUM_STARTING_WORKERS } from "./constants";
 import { v4 as uuidv4 } from "uuid";
 
 const convertAsync = promisify(convert);
+
+let scheduler: Tesseract.Scheduler;
 
 const MIN_ROTATION_CONFIDENCE = 60;
 
@@ -21,6 +24,28 @@ const defaultLLMParams: LLMParams = {
   presencePenalty: 0, // OpenAI defaults to 0
   temperature: 0,
   topP: 1, // OpenAI defaults to 1
+};
+
+const addWorker = async () => {
+  const worker = await Tesseract.createWorker("eng");
+  scheduler.addWorker(worker);
+};
+
+export const initTesseractScheduler = async (numWorkers: number) => {
+  scheduler = scheduler || Tesseract.createScheduler();
+  let resArr = Array(numWorkers);
+
+  for (let i = 0; i < numWorkers; i++) {
+    resArr[i] = addWorker();
+  }
+
+  await Promise.all(resArr);
+
+  return true;
+};
+
+export const terminateScheduler = () => {
+  return scheduler.terminate();
 };
 
 export const validateLLMParams = (params: Partial<LLMParams>): LLMParams => {
@@ -163,7 +188,7 @@ export const getTextFromImage = async (
     // @TODO: How can we generalize this to non eng languages?
     const {
       data: { confidence },
-    } = await Tesseract.recognize(croppedBuffer, "eng");
+    } = await scheduler.addJob("recognize", croppedBuffer);
 
     return { confidence };
   } catch (error) {
@@ -211,12 +236,14 @@ const determineOptimalRotation = async (
 export const convertPdfToImages = async ({
   correctOrientation,
   localPath,
+  maxTesseractWorkers,
   pagesToConvertAsImages,
   tempDir,
   trimEdges,
 }: {
   correctOrientation: boolean;
   localPath: string;
+  maxTesseractWorkers: number;
   pagesToConvertAsImages: number | number[];
   tempDir: string;
   trimEdges: boolean;
@@ -235,6 +262,31 @@ export const convertPdfToImages = async ({
     const convertResults = await storeAsImage.bulk(pagesToConvertAsImages, {
       responseType: "buffer",
     });
+
+    if (correctOrientation) {
+      const numRequiredWorkers = convertResults.length * 4;
+      let numNewWorkers = numRequiredWorkers - NUM_STARTING_WORKERS;
+
+      if (maxTesseractWorkers !== -1) {
+        const numPreviouslyInitiatedWorkers =
+          maxTesseractWorkers < NUM_STARTING_WORKERS
+            ? maxTesseractWorkers
+            : NUM_STARTING_WORKERS;
+
+        if (numRequiredWorkers > numPreviouslyInitiatedWorkers) {
+          numNewWorkers = Math.min(
+            numRequiredWorkers - numPreviouslyInitiatedWorkers,
+            maxTesseractWorkers - numPreviouslyInitiatedWorkers
+          );
+        } else {
+          numNewWorkers = 0;
+        }
+      }
+
+      // Add more workers if needed
+      if (numNewWorkers > 0) initTesseractScheduler(numNewWorkers);
+    }
+
     await Promise.all(
       convertResults.map(async (result) => {
         if (!result || !result.buffer) {

--- a/node-zerox/src/utils.ts
+++ b/node-zerox/src/utils.ts
@@ -14,8 +14,6 @@ import { v4 as uuidv4 } from "uuid";
 
 const convertAsync = promisify(convert);
 
-const MIN_ROTATION_CONFIDENCE = 60;
-
 const defaultLLMParams: LLMParams = {
   frequencyPenalty: 0, // OpenAI defaults to 0
   maxTokens: 2000,
@@ -24,13 +22,28 @@ const defaultLLMParams: LLMParams = {
   topP: 1, // OpenAI defaults to 1
 };
 
+interface CleanupImageProps {
+  correctOrientation: boolean;
+  imageBuffer: Buffer;
+  scheduler: Tesseract.Scheduler | null;
+  trimEdges: boolean;
+}
+
 export const getTesseractScheduler = async () => {
   return Tesseract.createScheduler();
 };
 
 const createAndAddWorker = async (scheduler: Tesseract.Scheduler) => {
-  const worker = await Tesseract.createWorker("eng");
-  scheduler.addWorker(worker);
+  const worker = await Tesseract.createWorker("eng", 2, {
+    legacyCore: true,
+    legacyLang: true,
+  });
+
+  await worker.setParameters({
+    tessedit_pageseg_mode: Tesseract.PSM.OSD_ONLY,
+  });
+
+  return scheduler.addWorker(worker);
 };
 
 export const addWorkersToTesseractScheduler = async ({
@@ -42,9 +55,7 @@ export const addWorkersToTesseractScheduler = async ({
 }) => {
   let resArr = Array.from({ length: numWorkers });
 
-  resArr.map(() => createAndAddWorker(scheduler));
-
-  await Promise.all(resArr);
+  await Promise.all(resArr.map(() => createAndAddWorker(scheduler)));
 
   return true;
 };
@@ -168,44 +179,6 @@ export const downloadFile = async ({
   return { extension, localPath };
 };
 
-// Extract text confidence from image buffer using Tesseract
-export const getTextFromImage = async ({
-  buffer,
-  scheduler,
-}: {
-  buffer: Buffer;
-  scheduler: Tesseract.Scheduler;
-}): Promise<{ confidence: number }> => {
-  try {
-    // Get image and metadata
-    const image = sharp(buffer);
-    const metadata = await image.metadata();
-
-    // Crop to a 150px wide column in the center of the document.
-    // This section produced the highest confidence/speed tradeoffs.
-    const cropWidth = 150;
-    const cropHeight = metadata.height || 0;
-    const left = Math.max(0, Math.floor((metadata.width! - cropWidth) / 2));
-    const top = 0;
-
-    // Extract the cropped image
-    const croppedBuffer = await image
-      .extract({ left, top, width: cropWidth, height: cropHeight })
-      .toBuffer();
-
-    // Pass the croppedBuffer to Tesseract.recognize
-    // @TODO: How can we generalize this to non eng languages?
-    const {
-      data: { confidence },
-    } = await scheduler.addJob("recognize", croppedBuffer);
-
-    return { confidence };
-  } catch (error) {
-    console.error("Error during OCR:", error);
-    return { confidence: 0 };
-  }
-};
-
 // Determine the optimal image orientation based on OCR confidence
 // Run Tesseract on 4 image orientations and compare the outputs
 const determineOptimalRotation = async ({
@@ -215,35 +188,16 @@ const determineOptimalRotation = async ({
   image: sharp.Sharp;
   scheduler: Tesseract.Scheduler;
 }): Promise<number> => {
-  const rotations = [0, 90, 180, 270];
+  const imageBuffer = await image.toBuffer();
+  const {
+    data: { orientation_confidence, orientation_degrees },
+  } = await scheduler.addJob("detect", imageBuffer);
 
-  const results = await Promise.all(
-    rotations.map(async (rotation) => {
-      const rotatedImageBuffer = await image
-        .clone()
-        .rotate(rotation)
-        .toBuffer();
-      const { confidence } = await getTextFromImage({
-        buffer: rotatedImageBuffer,
-        scheduler,
-      });
-      return { rotation, confidence };
-    })
-  );
-
-  // Find the rotation with the best confidence score
-  const bestResult = results.reduce((best, current) =>
-    current.confidence > best.confidence ? current : best
-  );
-
-  if (
-    bestResult.confidence >= MIN_ROTATION_CONFIDENCE &&
-    bestResult.rotation !== 0
-  ) {
+  if (orientation_degrees) {
     console.log(
-      `Reorienting image ${bestResult.rotation} degrees (confidence: ${bestResult.confidence}%)`
+      `Reorienting image ${orientation_degrees} degrees (confidence: ${orientation_confidence}%)`
     );
-    return bestResult.rotation;
+    return orientation_degrees;
   }
   return 0;
 };
@@ -282,7 +236,7 @@ export const convertPdfToImages = async ({
     });
 
     if (correctOrientation) {
-      const numRequiredWorkers = convertResults.length * 4;
+      const numRequiredWorkers = convertResults.length;
       let numNewWorkers = numRequiredWorkers - NUM_STARTING_WORKERS;
 
       if (maxTesseractWorkers !== -1) {
@@ -317,27 +271,12 @@ export const convertPdfToImages = async ({
         if (!result.page) throw new Error("Could not identify page data");
         const paddedPageNumber = result.page.toString().padStart(5, "0");
 
-        const image = sharp(result.buffer);
-
-        if (trimEdges) {
-          image.trim();
-        }
-
-        // scheduler would always be non-null if correctOrientation is true
-        // Adding this check to satisfy typescript
-        if (correctOrientation && scheduler) {
-          const optimalRotation = await determineOptimalRotation({
-            image,
-            scheduler,
-          });
-
-          if (optimalRotation) {
-            image.rotate(optimalRotation);
-          }
-        }
-
-        // Correct the image orientation
-        const correctedBuffer = await image.toBuffer();
+        const correctedBuffer = await cleanupImage({
+          correctOrientation,
+          imageBuffer: result.buffer,
+          scheduler,
+          trimEdges,
+        });
 
         const imagePath = path.join(
           tempDir,
@@ -390,4 +329,35 @@ export const convertKeysToSnakeCase = (
   return Object.fromEntries(
     Object.entries(obj).map(([key, value]) => [camelToSnakeCase(key), value])
   );
+};
+
+export const cleanupImage = async ({
+  correctOrientation,
+  imageBuffer,
+  scheduler,
+  trimEdges,
+}: CleanupImageProps) => {
+  const image = sharp(imageBuffer);
+
+  // Trim extra space around the content in the image
+  if (trimEdges) {
+    image.trim();
+  }
+
+  // scheduler would always be non-null if correctOrientation is true
+  // Adding this check to satisfy typescript
+  if (correctOrientation && scheduler) {
+    const optimalRotation = await determineOptimalRotation({
+      image,
+      scheduler,
+    });
+
+    if (optimalRotation) {
+      image.rotate(optimalRotation);
+    }
+  }
+
+  // Correct the image orientation
+  const correctedBuffer = await image.toBuffer();
+  return correctedBuffer;
 };


### PR DESCRIPTION
This PR replaces the orientation correction mechanism with Tesseract's. It resulted in **~60-70%** reduction in time taken by the orientation correction step (1.862s -> 756.95ms).

The confidence returned by the Tesseract is based on the number of glyphs detected and can result in extremely low scores (<1) even for correct detections. This is why this PR doesn't have a confidence threshold, as finding a score that works universally is a hard problem.

This is how both approaches fared on our test data set of 47 randomly rotated pages:
|Orientation detection mechanism|Number of misclassifications| Percentage of misclassifications |
|--|--|--|
|In-house chunking strategy|23|48.9%|
|**Tesseract OSD**|**5**|**10.6%**|

Before this change, the test resulted in ~63% accuracy. The dataset was randomly rotated to either 0, 90, 180, or 270 degrees, indicated as "randomly rotated" in the table below. This dataset was then used to compare Tesseract OSD and the chunking strategy. Tesseract OSD produced almost perfect results (61%) coming in close to the original Zerox performance of 63% (This 3% step down is discussed later on). On the other hand, the chunking strategy produced 47.10% accuracy (25% down).

|Orientation detection mechanism|Dataset|Accuracy|
|--|--|--|
|In-house chunking strategy|Zerox test|~63% (baseline)|
|**Tesseract OSD**|Zerox test - randomly rotated|~61%|
|In-house chunking strategy|Zerox test - randomly rotated|~47.10%|

This randomly rotated dataset can be found [here](https://github.com/getomni-ai/zerox/commit/05d96df8cf835850d22b2131750b86f25676ed50).

### Why the 2% step down?
Well, Tesseract failed to identify orientation for two images with the message "Too few characters. Skipping this page". For one of the [image](https://github.com/getomni-ai/zerox/blob/main/shared/inputs/0019.png), cropping in to the receipt fixed this problem.
Tesseract has a configuration `min_characters_to_try`, which was set to 0 but got the same result.

### And...
This PR also adds the image correction (trimming and orientation correction) if the image (PNG) is passed, which were bypassed before. This required in change in the `temp` directory folder structure which is expected to have no user facing impact.

#### Note:
When running this for the first time, tesseract downloads a file `osd.traineddata` sized 10.6MB