### PR TITLE
Update py-zerox installation instructions for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Request #3 => page_2_markdown + page_3_image
 
 ### Installation:
 
-- Install **poppler-utils** on the system, it should be available in path variable
+- Install **poppler** on the system, it should be available in path variable. See the [pdf2image documentation](https://pdf2image.readthedocs.io/en/latest/installation.html) for instructions by platform.
 - Install py-zerox:
 
 ```sh


### PR DESCRIPTION
I made a little tweak to the installation instructions; currently they say install **poppler-utils**. A google search for that sends you to a python package on PyPI from 2020 which isn't maintained anymore. 

I think what's actually needed is an install of **poppler**; at least, that's what the dependency `pdf2image` said in its documentation. I linked to those docs for further instructions. After installing poppler with brew, my py-zerox install is working properly.