### PR TITLE
Add poppler_path Argument to zerox Function

### DIFF
--- a/py_zerox/pyzerox/core/zerox.py
+++ b/py_zerox/pyzerox/core/zerox.py
@@ -133,7 +133,7 @@ async def zerox(
                                                  **subset_pdf_create_kwargs)
 
         # Convert the file to a series of images, below function returns a list of image paths in page order
-        images = await convert_pdf_to_images(image_density=image_density, image_height=image_height, local_path=local_path, temp_dir=temp_directory)
+        images = await convert_pdf_to_images(image_density=image_density, image_height=image_height, local_path=local_path, temp_dir=temp_directory, poppler_path=poppler_path)
 
         if maintain_format:
             for image in images:

--- a/py_zerox/pyzerox/core/zerox.py
+++ b/py_zerox/pyzerox/core/zerox.py
@@ -131,6 +131,12 @@ async def zerox(
                                     "save_directory":temp_directory, "suffix":"_selected_pages"}
             local_path = await asyncio.to_thread(create_selected_pages_pdf, 
                                                  **subset_pdf_create_kwargs)
+        
+        # explicitly pass poppler path via kwargs
+        if "poppler_path" in kwargs:
+            poppler_path = kwargs["poppler_path"]
+        else:
+            poppler_path = None
 
         # Convert the file to a series of images, below function returns a list of image paths in page order
         images = await convert_pdf_to_images(image_density=image_density, image_height=image_height, local_path=local_path, temp_dir=temp_directory, poppler_path=poppler_path)

--- a/py_zerox/pyzerox/processor/pdf.py
+++ b/py_zerox/pyzerox/processor/pdf.py
@@ -11,7 +11,7 @@ from ..constants import PDFConversionDefaultOptions, Messages
 from ..models import litellmmodel
 
 
-async def convert_pdf_to_images(image_density: int, image_height: tuple[Optional[int], int], local_path: str, temp_dir: str) -> List[str]:
+async def convert_pdf_to_images(image_density: int, image_height: tuple[Optional[int], int], local_path: str, temp_dir: str, poppler_path: str) -> List[str]:
     """Converts a PDF file to a series of images in the temp_dir. Returns a list of image paths in page order."""
     options = {
         "pdf_path": local_path,
@@ -22,6 +22,7 @@ async def convert_pdf_to_images(image_density: int, image_height: tuple[Optional
         "thread_count": PDFConversionDefaultOptions.THREAD_COUNT,
         "use_pdftocairo": PDFConversionDefaultOptions.USE_PDFTOCAIRO,
         "paths_only": True,
+        "poppler_path": poppler_path
     }
 
     try:

--- a/py_zerox/pyzerox/processor/pdf.py
+++ b/py_zerox/pyzerox/processor/pdf.py
@@ -11,7 +11,7 @@ from ..constants import PDFConversionDefaultOptions, Messages
 from ..models import litellmmodel
 
 
-async def convert_pdf_to_images(image_density: int, image_height: tuple[Optional[int], int], local_path: str, temp_dir: str, poppler_path: str) -> List[str]:
+async def convert_pdf_to_images(image_density: int, image_height: tuple[Optional[int], int], local_path: str, temp_dir: str, poppler_path: str = None) -> List[str]:
     """Converts a PDF file to a series of images in the temp_dir. Returns a list of image paths in page order."""
     options = {
         "pdf_path": local_path,


### PR DESCRIPTION
**Description:**  
The `convert_from_path` function in the `pdf2image` library currently supports a `poppler_path` argument, which allows users to specify the path to the Poppler binaries.  

This feature is particularly useful for environments where installing Poppler system-wide (e.g., on Windows without administrative rights) is challenging.  

**Request:**  
Please add support for the `poppler_path` argument in the `zerox` function to provide similar flexibility for specifying the Poppler binaries path.  

**Reason:**  
- Simplifies the use of `zerox` in restricted environments, such as Windows without admin rights.  
- Aligns functionality between `convert_from_path` and `zerox`, improving consistency within the library.  

Thank you for considering this enhancement!