### PR TITLE
Remove unnecessary warning for custom system prompt assignment

### DIFF
--- a/py_zerox/pyzerox/models/modellitellm.py
+++ b/py_zerox/pyzerox/models/modellitellm.py
@@ -1,6 +1,5 @@
 import os
 import aiohttp
-import warnings
 import litellm
 from typing import List, Dict, Any, Optional
 
@@ -47,9 +46,7 @@ class litellmmodel(BaseModel):
     def system_prompt(self, prompt: str) -> None:
         '''
         Sets/overrides the system prompt for the model.
-        Will raise a friendly warning to notify the user. 
         '''
-        warnings.warn(f"{Messages.CUSTOM_SYSTEM_PROMPT_WARNING}. Default prompt for zerox is:\n {DEFAULT_SYSTEM_PROMPT}")
         self._system_prompt = prompt
 
     ## custom method on top of BaseModel


### PR DESCRIPTION
The warning in the system_prompt setter has been removed because it is unnecessary. The custom_system_prompt is explicitly assigned by the user, making the warning redundant. Keeping this warning adds unnecessary noise to logs without providing meaningful value.

Since setting a custom system prompt is an intentional action, users do not need to be notified via a warning. This change improves code clarity and reduces log clutter.