### PR TITLE
added image compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ const result = await zerox({
   imageHeight: 2048, // Maximum height for converted images
   llmParams: {}, // Additional parameters to pass to the LLM
   maintainFormat: false, // Slower but helps maintain consistent formatting
+  maxImageSize: 15, // Maximum size of images to compress, defaults to 15MB
   maxRetries: 1, // Number of retries to attempt on a failed page, defaults to 1
   maxTesseractWorkers: -1, // Maximum number of Tesseract workers. Zerox will start with a lower number and only reach maxTesseractWorkers if needed
   model: ModelOptions.OPENAI_GPT_4O, // Model to use (supports various models from different providers)

--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -180,7 +180,6 @@ export const zerox = async ({
         return compressedPath;
       });
 
-      // Process compressions in parallel for better performance
       imagePaths = await Promise.all(compressPromises);
     }
 

--- a/node-zerox/src/types.ts
+++ b/node-zerox/src/types.ts
@@ -23,6 +23,7 @@ export interface ZeroxArgs {
   imageHeight?: number;
   llmParams?: Partial<LLMParams>;
   maintainFormat?: boolean;
+  maxImageSize?: number;
   maxRetries?: number;
   maxTesseractWorkers?: number;
   model?: ModelOptions | string;

--- a/node-zerox/src/utils/image.ts
+++ b/node-zerox/src/utils/image.ts
@@ -83,7 +83,6 @@ export const compressImage = async (
   // Convert maxSize from MB to bytes
   const maxBytes = maxSize * 1024 * 1024;
 
-  // If image is already smaller than maxSize, return original
   if (image.length <= maxBytes) {
     return image;
   }
@@ -107,7 +106,6 @@ export const compressImage = async (
 
     return compressedImage;
   } catch (error) {
-    // if image compression fails, return original image
     return image;
   }
 };


### PR DESCRIPTION
changes:
- auto-compress images if image size too large for LLM to parse. 
- added a new param: `maxImageSize`, default = 15MB. 
- added a function, `compressImage`, that compress an image to certain file size