### PR TITLE
added excel support

### DIFF
--- a/node-zerox/src/index.ts
+++ b/node-zerox/src/index.ts
@@ -14,8 +14,10 @@ import {
   convertHeicToJpeg,
   convertPdfToImages,
   downloadFile,
+  extractPagesFromStructuredDataFile,
   getTesseractScheduler,
   isCompletionResponse,
+  isStructuredDataFile,
   prepareWorkersForImageProcessing,
   runRetries,
   splitSchema,
@@ -69,8 +71,11 @@ export const zerox = async ({
   let extracted: Record<string, unknown> | null = null;
   let inputTokenCount: number = 0;
   let outputTokenCount: number = 0;
+  let numSuccessfulOCRRequests: number = 0;
+  let numFailedOCRRequests: number = 0;
   let priorPage: string = "";
-  const pages: Page[] = [];
+  let pages: Page[] = [];
+  let imagePaths: string[] = [];
   const startTime = new Date();
 
   if (openaiAPIKey && openaiAPIKey.length > 0) {
@@ -135,178 +140,183 @@ export const zerox = async ({
       pagesToConvertAsImages.sort((a, b) => a - b);
     }
 
-    // Read the image file or convert the file to images
-    let imagePaths: string[] = [];
-    if (extension === ".png" || extension === ".jpg" || extension === ".jpeg") {
-      imagePaths = [localPath];
-    } else if (extension === ".heic") {
-      const imagePath = await convertHeicToJpeg({
-        localPath,
-        tempDir: sourceDirectory,
-      });
-      imagePaths = [imagePath];
+    // Check if the file is a structured data file (like Excel).
+    // If so, skip the image conversion process and extract the pages directly
+    if (isStructuredDataFile(localPath)) {
+      pages = await extractPagesFromStructuredDataFile(localPath);
     } else {
-      let pdfPath: string;
-      if (extension === ".pdf") {
-        pdfPath = localPath;
-      } else {
-        // Convert file to PDF if necessary
-        pdfPath = await convertFileToPdf({
-          extension,
+      // Read the image file or convert the file to images
+      if (
+        extension === ".png" ||
+        extension === ".jpg" ||
+        extension === ".jpeg"
+      ) {
+        imagePaths = [localPath];
+      } else if (extension === ".heic") {
+        const imagePath = await convertHeicToJpeg({
           localPath,
           tempDir: sourceDirectory,
         });
+        imagePaths = [imagePath];
+      } else {
+        let pdfPath: string;
+        if (extension === ".pdf") {
+          pdfPath = localPath;
+        } else {
+          // Convert file to PDF if necessary
+          pdfPath = await convertFileToPdf({
+            extension,
+            localPath,
+            tempDir: sourceDirectory,
+          });
+        }
+        imagePaths = await convertPdfToImages({
+          pdfPath,
+          imageDensity,
+          imageHeight,
+          pagesToConvertAsImages,
+          tempDir: sourceDirectory,
+        });
       }
-      imagePaths = await convertPdfToImages({
-        pdfPath,
-        imageDensity,
-        imageHeight,
-        pagesToConvertAsImages,
-        tempDir: sourceDirectory,
-      });
-    }
 
-    // Compress images if maxImageSize is specified
-    if (maxImageSize && maxImageSize > 0) {
-      const compressPromises = imagePaths.map(async (imagePath, index) => {
-        const imageBuffer = await fs.readFile(imagePath);
-        const compressedBuffer = await compressImage(imageBuffer, maxImageSize);
-        const originalName = path.basename(imagePath, path.extname(imagePath));
-        const compressedPath = path.join(
-          sourceDirectory,
-          `${originalName}_compressed.png`
-        );
-        await fs.writeFile(compressedPath, compressedBuffer);
-        return compressedPath;
-      });
-
-      imagePaths = await Promise.all(compressPromises);
-    }
-
-    if (correctOrientation) {
-      await prepareWorkersForImageProcessing({
-        maxTesseractWorkers,
-        numImages: imagePaths.length,
-        scheduler,
-      });
-    }
-
-    // Start processing OCR using LLM
-    let numSuccessfulOCRRequests: number = 0;
-    let numFailedOCRRequests: number = 0;
-
-    const modelInstance = createModel({
-      credentials,
-      llmParams,
-      model,
-      provider: modelProvider,
-    });
-
-    const extractionModelInstance = createModel({
-      credentials: extractionCredentials,
-      llmParams: extractionLlmParams,
-      model: extractionModel,
-      provider: extractionModelProvider,
-    });
-
-    if (!extractOnly) {
-      const processOCR = async (
-        imagePath: string,
-        pageNumber: number,
-        maintainFormat: boolean
-      ): Promise<Page> => {
-        const imageBuffer = await fs.readFile(imagePath);
-        const correctedBuffer = await cleanupImage({
-          correctOrientation,
-          imageBuffer,
-          scheduler,
-          trimEdges,
+      // Compress images if maxImageSize is specified
+      if (maxImageSize && maxImageSize > 0) {
+        const compressPromises = imagePaths.map(async (imagePath: string) => {
+          const imageBuffer = await fs.readFile(imagePath);
+          const compressedBuffer = await compressImage(
+            imageBuffer,
+            maxImageSize
+          );
+          const originalName = path.basename(
+            imagePath,
+            path.extname(imagePath)
+          );
+          const compressedPath = path.join(
+            sourceDirectory,
+            `${originalName}_compressed.png`
+          );
+          await fs.writeFile(compressedPath, compressedBuffer);
+          return compressedPath;
         });
 
-        let page: Page;
-        try {
-          let rawResponse: CompletionResponse | ExtractionResponse;
-          if (customModelFunction) {
-            rawResponse = await runRetries(
-              () =>
-                customModelFunction({
-                  buffer: correctedBuffer,
-                  image: imagePath,
-                  maintainFormat,
-                  priorPage,
-                }),
-              maxRetries,
-              pageNumber
+        imagePaths = await Promise.all(compressPromises);
+      }
+
+      if (correctOrientation) {
+        await prepareWorkersForImageProcessing({
+          maxTesseractWorkers,
+          numImages: imagePaths.length,
+          scheduler,
+        });
+      }
+
+      // Start processing OCR using LLM
+      const modelInstance = createModel({
+        credentials,
+        llmParams,
+        model,
+        provider: modelProvider,
+      });
+
+      if (!extractOnly) {
+        const processOCR = async (
+          imagePath: string,
+          pageNumber: number,
+          maintainFormat: boolean
+        ): Promise<Page> => {
+          const imageBuffer = await fs.readFile(imagePath);
+          const correctedBuffer = await cleanupImage({
+            correctOrientation,
+            imageBuffer,
+            scheduler,
+            trimEdges,
+          });
+
+          let page: Page;
+          try {
+            let rawResponse: CompletionResponse | ExtractionResponse;
+            if (customModelFunction) {
+              rawResponse = await runRetries(
+                () =>
+                  customModelFunction({
+                    buffer: correctedBuffer,
+                    image: imagePath,
+                    maintainFormat,
+                    priorPage,
+                  }),
+                maxRetries,
+                pageNumber
+              );
+            } else {
+              rawResponse = await runRetries(
+                () =>
+                  modelInstance.getCompletion(OperationMode.OCR, {
+                    image: correctedBuffer,
+                    maintainFormat,
+                    priorPage,
+                  }),
+                maxRetries,
+                pageNumber
+              );
+            }
+            const response = CompletionProcessor.process(
+              OperationMode.OCR,
+              rawResponse
             );
-          } else {
-            rawResponse = await runRetries(
-              () =>
-                modelInstance.getCompletion(OperationMode.OCR, {
-                  image: correctedBuffer,
-                  maintainFormat,
-                  priorPage,
-                }),
-              maxRetries,
-              pageNumber
-            );
-          }
-          const response = CompletionProcessor.process(
-            OperationMode.OCR,
-            rawResponse
-          );
 
-          inputTokenCount += response.inputTokens;
-          outputTokenCount += response.outputTokens;
+            inputTokenCount += response.inputTokens;
+            outputTokenCount += response.outputTokens;
 
-          if (isCompletionResponse(OperationMode.OCR, response)) {
-            priorPage = response.content;
-          }
+            if (isCompletionResponse(OperationMode.OCR, response)) {
+              priorPage = response.content;
+            }
 
-          page = {
-            ...response,
-            page: pageNumber,
-            status: PageStatus.SUCCESS,
-          };
-          numSuccessfulOCRRequests++;
-        } catch (error) {
-          console.error(`Failed to process image ${imagePath}:`, error);
-          if (errorMode === ErrorMode.THROW) {
-            throw error;
+            page = {
+              ...response,
+              page: pageNumber,
+              status: PageStatus.SUCCESS,
+            };
+            numSuccessfulOCRRequests++;
+          } catch (error) {
+            console.error(`Failed to process image ${imagePath}:`, error);
+            if (errorMode === ErrorMode.THROW) {
+              throw error;
+            }
+
+            page = {
+              content: "",
+              contentLength: 0,
+              error: `Failed to process page ${pageNumber}: ${error}`,
+              page: pageNumber,
+              status: PageStatus.ERROR,
+            };
+            numFailedOCRRequests++;
           }
 
-          page = {
-            content: "",
-            contentLength: 0,
-            error: `Failed to process page ${pageNumber}: ${error}`,
-            page: pageNumber,
-            status: PageStatus.ERROR,
-          };
-          numFailedOCRRequests++;
-        }
+          return page;
+        };
 
-        return page;
-      };
-
-      if (maintainFormat) {
-        // Use synchronous processing
-        for (let i = 0; i < imagePaths.length; i++) {
-          const page = await processOCR(imagePaths[i], i + 1, true);
-          pages.push(page);
-          if (page.status === PageStatus.ERROR) {
-            break;
+        if (maintainFormat) {
+          // Use synchronous processing
+          for (let i = 0; i < imagePaths.length; i++) {
+            const page = await processOCR(imagePaths[i], i + 1, true);
+            pages.push(page);
+            if (page.status === PageStatus.ERROR) {
+              break;
+            }
           }
-        }
-      } else {
-        const limit = pLimit(concurrency);
-        await Promise.all(
-          imagePaths.map((imagePath, i) =>
-            limit(() =>
-              processOCR(imagePath, i + 1, false).then((page) => {
-                pages[i] = page;
-              })
+        } else {
+          const limit = pLimit(concurrency);
+          await Promise.all(
+            imagePaths.map((imagePath, i) =>
+              limit(() =>
+                processOCR(imagePath, i + 1, false).then((page) => {
+                  pages[i] = page;
+                })
+              )
             )
-          )
-        );
+          );
+        }
       }
     }
 
@@ -315,6 +325,13 @@ export const zerox = async ({
     let numFailedExtractionRequests: number = 0;
 
     if (schema) {
+      const extractionModelInstance = createModel({
+        credentials: extractionCredentials,
+        llmParams: extractionLlmParams,
+        model: extractionModel,
+        provider: extractionModelProvider,
+      });
+
       const { fullDocSchema, perPageSchema } = splitSchema(
         schema,
         extractPerPage
@@ -370,9 +387,10 @@ export const zerox = async ({
       };
 
       if (perPageSchema) {
-        const inputs = extractOnly
-          ? imagePaths.map((imagePath) => [imagePath])
-          : pages.map((page) => page.content || "");
+        const inputs =
+          extractOnly && !isStructuredDataFile(localPath)
+            ? imagePaths.map((imagePath) => [imagePath])
+            : pages.map((page) => page.content || "");
 
         extractionTasks.push(
           ...inputs.map((input, i) =>
@@ -382,13 +400,14 @@ export const zerox = async ({
       }
 
       if (fullDocSchema) {
-        const input: string | string[] = extractOnly
-          ? imagePaths
-          : pages
-              .map((page, i) =>
-                i === 0 ? page.content : "\n<hr><hr>\n" + page.content
-              )
-              .join("");
+        const input =
+          extractOnly && !isStructuredDataFile(localPath)
+            ? imagePaths
+            : pages
+                .map((page, i) =>
+                  i === 0 ? page.content : "\n<hr><hr>\n" + page.content
+                )
+                .join("");
 
         extractionTasks.push(
           (async () => {
@@ -497,7 +516,7 @@ export const zerox = async ({
       outputTokens: outputTokenCount,
       pages: formattedPages,
       summary: {
-        totalPages: imagePaths.length,
+        totalPages: pages.length,
         ocr: !extractOnly
           ? {
               successful: numSuccessfulOCRRequests,

--- a/node-zerox/src/types.ts
+++ b/node-zerox/src/types.ts
@@ -218,3 +218,9 @@ export interface Summary {
     failed: number;
   } | null;
 }
+
+export interface ExcelSheetContent {
+  sheetName: string;
+  content: string;
+  contentLength: number;
+}

--- a/node-zerox/src/utils/file.ts
+++ b/node-zerox/src/utils/file.ts
@@ -9,8 +9,10 @@ import { v4 as uuidv4 } from "uuid";
 import { convert } from "libreoffice-convert";
 import { WriteImageResponse } from "pdf2pic/dist/types/convertResponse";
 import heicConvert from "heic-convert";
+import xlsx from "xlsx";
 
 import { isValidUrl } from "./common";
+import { ExcelSheetContent, Page, PageStatus } from "../types";
 
 const convertAsync = promisify(convert);
 
@@ -162,4 +164,94 @@ export const convertPdfToImages = async ({
     console.error("Error during PDF conversion:", err);
     throw err;
   }
+};
+
+// Converts an Excel file to HTML format
+export const convertExcelToHtml = async (
+  filePath: string
+): Promise<ExcelSheetContent[]> => {
+  const tableClass = "zerox-excel-table";
+
+  try {
+    if (!(await fs.pathExists(filePath))) {
+      throw new Error(`Excel file not found: ${filePath}`);
+    }
+
+    const workbook = xlsx.readFile(filePath, {
+      type: "file",
+      cellStyles: true,
+      cellHTML: true,
+    });
+
+    if (!workbook || !workbook.SheetNames || workbook.SheetNames.length === 0) {
+      throw new Error("Invalid Excel file or no sheets found");
+    }
+
+    const sheets: ExcelSheetContent[] = [];
+
+    for (const sheetName of workbook.SheetNames) {
+      const worksheet = workbook.Sheets[sheetName];
+
+      let sheetContent = "";
+      sheetContent += `<h2>Sheet: ${sheetName}</h2>\n`;
+
+      const sheetHtml = xlsx.utils.sheet_to_html(worksheet, {
+        id: `sheet-${sheetName.replace(/[^a-zA-Z0-9]/g, "-")}`,
+        editable: false,
+      });
+
+      let processedHtml = sheetHtml.replace(
+        "<table",
+        `<table class="${tableClass}"`
+      );
+      sheetContent += processedHtml;
+
+      sheets.push({
+        sheetName,
+        content: sheetContent,
+        contentLength: sheetContent.length,
+      });
+    }
+
+    return sheets;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// Checks if a file is an Excel file
+export const isExcelFile = (filePath: string): boolean => {
+  const extension = path.extname(filePath).toLowerCase();
+  return (
+    extension === ".xlsx" ||
+    extension === ".xls" ||
+    extension === ".xlsm" ||
+    extension === ".xlsb"
+  );
+};
+
+// Checks if a file is a structured data file (like Excel)
+export const isStructuredDataFile = (filePath: string): boolean => {
+  return isExcelFile(filePath);
+};
+
+// Extracts pages from a structured data file (like Excel)
+export const extractPagesFromStructuredDataFile = async (
+  filePath: string
+): Promise<Page[]> => {
+  if (isExcelFile(filePath)) {
+    const sheets = await convertExcelToHtml(filePath);
+    const pages: Page[] = [];
+    sheets.forEach((sheet: ExcelSheetContent, index: number) => {
+      pages.push({
+        content: sheet.content,
+        contentLength: sheet.contentLength,
+        page: index + 1,
+        status: PageStatus.SUCCESS,
+      });
+    });
+    return pages;
+  }
+
+  return [];
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "sharp": "^0.33.5",
         "tesseract.js": "^5.1.1",
         "util": "^0.12.5",
-        "uuid": "^11.0.3"
+        "uuid": "^11.0.3",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/fs-extra": "^11.0.4",
@@ -2919,6 +2920,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -3339,6 +3349,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3420,6 +3443,15 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -3493,6 +3525,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -3999,6 +4043,15 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -6088,6 +6141,18 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -6588,6 +6653,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -6625,6 +6708,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "sharp": "^0.33.5",
     "tesseract.js": "^5.1.1",
     "util": "^0.12.5",
-    "uuid": "^11.0.3"
+    "uuid": "^11.0.3",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
Changes:
- if an excel file is passed, we use `xlsx` to convert it to HTML. Each sheet is a page. Then, we skip OCR steps and directly pass HTML results to extraction steps. 
- added `convertExcelToHTML()` util function

Example excel file: 
[file_example_XLSX_50.xlsx](https://github.com/user-attachments/files/19079205/file_example_XLSX_50.xlsx)
