### PR TITLE
Support passing api_key (and related params) via kwargs in litellmmodel

### DIFF
--- a/py_zerox/pyzerox/models/modellitellm.py
+++ b/py_zerox/pyzerox/models/modellitellm.py
@@ -52,7 +52,12 @@ class litellmmodel(BaseModel):
     ## custom method on top of BaseModel
     def validate_environment(self) -> None:
         """Validates the environment variables required for the model."""
-        env_config = litellm.validate_environment(model=self.model)
+        env_config = litellm.validate_environment(
+            model=self.model,
+            api_key=self.kwargs.get("api_key"),
+            api_base=self.kwargs.get("api_base"),
+            api_version=self.kwargs.get("api_version"),
+        )
 
         if not env_config["keys_in_environment"]:
             raise MissingEnvironmentVariables(extra_info=env_config)
@@ -64,7 +69,7 @@ class litellmmodel(BaseModel):
         
     def validate_access(self) -> None:
         """Validates access to the model -> if environment variables are set correctly with correct values."""
-        if not litellm.check_valid_key(model=self.model,api_key=None):
+        if not litellm.check_valid_key(model=self.model, api_key=self.kwargs.get("api_key")):
             raise ModelAccessError(extra_info={"model": self.model})
         
 


### PR DESCRIPTION
Target Issue : #190 

This PR fixes a limitation in litellmmodel where API credentials had to be provided exclusively via environment variables. Even if api_key (or api_base, api_version) was passed during initialization, it was never forwarded to validate_environment or validate_access, causing errors such as:
```
Required environment variable (keys) from the model are Missing. 
missing_keys: ['OPENAI_API_KEY']
```

## Changes
- Updated validate_environment and validate_access to forward api_key, api_base, and api_version from kwargs.
- This allows per-request credential injection instead of relying only on global environment variables.
